### PR TITLE
UUID Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ var grand = require('grand');
 
 grand.number(exclusiveMax)    // A random, positive number less than the exclusiveMax
 grand.integer(exclusiveMax)   // A random, positive integer less than the exclusiveMax
+grand.uuid()                  // A random uuid (v4) using node-uuid and accepting the v4 parameters (optional)
 grand.pick(array)             // A random item from the given array
 grand.letter()                // A random letter [A-Za-z]
 grand.wordChar()              // A random word character [A-Za-z0-9_]

--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ exports.integer = function (exclusiveMax) {
   return exports.number(exclusiveMax) | 0;
 };
 
+var uuid = require('node-uuid');
+
+exports.uuid = uuid.v4;
+
 exports.pick = function (array) {
   return array[exports.integer(array.length)];
 };

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mjijackson/grand/issues"
+  },
+  "dependencies": {
+    "node-uuid": "~1.4.1"
   }
 }


### PR DESCRIPTION
This generator uses the node-uuid package to generate a random uuid (v4).

```
var uuid = grand.uuid();
// => 97135ac5-ef50-4288-bdd6-ff8f19a8aa2a
```

It is the first external dependency for grand so I understand if it is problematic. There is always the option of porting a small fraction of code for generating a random uuid (v4).
